### PR TITLE
[FEAT-65]: Added token blacklisting to refresh token rotation

### DIFF
--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -5,9 +5,10 @@ import { JwtModule } from '@nestjs/jwt';
 import { UsersModule } from '../users/users.module';
 import { PassportModule } from '@nestjs/passport';
 import { AuthTokenStrategy, RefreshTokenStrategy } from './strategies';
+import { RedisModule } from 'src/redis/redis.module';
 
 @Module({
-  imports: [JwtModule, UsersModule, PassportModule],
+  imports: [JwtModule, UsersModule, PassportModule, RedisModule],
   providers: [AuthService, RefreshTokenStrategy, AuthTokenStrategy],
   controllers: [AuthController],
 })

--- a/src/modules/oAuth/oAuth.module.ts
+++ b/src/modules/oAuth/oAuth.module.ts
@@ -4,9 +4,10 @@ import { OAuthController } from './oAuth.controller';
 import { OAuthService } from './oAuth.service';
 import { UsersModule } from '../users/users.module';
 import { JwtModule } from '@nestjs/jwt';
+import { RedisModule } from 'src/redis/redis.module';
 
 @Module({
-  imports: [UsersModule, JwtModule],
+  imports: [UsersModule, JwtModule, RedisModule],
   controllers: [OAuthController],
   providers: [OAuthService, GoogleStrategy],
 })

--- a/src/modules/oAuth/test/oAuth.controller.spec.ts
+++ b/src/modules/oAuth/test/oAuth.controller.spec.ts
@@ -5,6 +5,7 @@ import { OAuthService } from '../oAuth.service';
 import { GoogleUserCreateDto } from '../dtos';
 import { ConfigService } from '@nestjs/config';
 import { OAuthResponse } from '../oAuth.types';
+import { RedisService } from 'src/redis/redis.service';
 
 const mockRes = {
   cookie: jest.fn<Response, [string, string, CookieOptions]>().mockReturnThis(),
@@ -33,6 +34,10 @@ const mockConfigSerivice = {
     }),
 };
 
+const mockRedisService = {
+  blacklistRefreshToken: jest.fn(),
+};
+
 describe('OAuthController', () => {
   let controller: OAuthController;
 
@@ -55,6 +60,7 @@ describe('OAuthController', () => {
           provide: ConfigService,
           useValue: mockConfigSerivice,
         },
+        { provide: RedisService, useValue: mockRedisService },
       ],
     }).compile();
 
@@ -82,7 +88,11 @@ describe('OAuthController', () => {
         lastName: 'Doe',
       };
 
-      await controller.googleAuthRedirect(oAuthResponse, mockRes);
+      await controller.googleAuthRedirect(
+        oAuthResponse,
+        mockRes,
+        'refresh-token',
+      );
 
       expect(mockRes.cookie).toHaveBeenCalledWith(
         'accessToken',

--- a/src/shared/decorators/cookies.decorator.ts
+++ b/src/shared/decorators/cookies.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const Cookies = createParamDecorator(
+  (data: string, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return data ? request.cookies?.[data] : request.cookies;
+  },
+);


### PR DESCRIPTION
Updated Auth logic so that the user cannot reuse their old refresh token after they get a new one.